### PR TITLE
Make items focusable

### DIFF
--- a/library/src/main/res/layout/item_file.xml
+++ b/library/src/main/res/layout/item_file.xml
@@ -3,6 +3,7 @@
     android:orientation="horizontal"
     android:background="@drawable/bg_clickable"
     android:clickable="true"
+    android:focusable="true"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 


### PR DESCRIPTION
It is unable to interact with library with keyboard. So this library is unusable at Android TV boxes and other devices with keyboard.
android:focusable="true" enables interaction.

![screenshot](https://cloud.githubusercontent.com/assets/8116529/13772993/bfe0d46e-ea9f-11e5-8c7c-359a36ee47d7.png)