### PR TITLE
Fix filters. Fixes #11 and #19

### DIFF
--- a/library/src/main/java/com/nbsp/materialfilepicker/utils/FileUtils.java
+++ b/library/src/main/java/com/nbsp/materialfilepicker/utils/FileUtils.java
@@ -23,21 +23,23 @@ public class FileUtils {
         File[] files = directory.listFiles();
         if (files != null && files.length > 0) {
             for (File f : files) {
-                if (f.isHidden()) {
-                    if (showHidden) {
+
+                if (f.isDirectory() && !directoriesFilter) {
+                    if (!f.isHidden() || (f.isHidden() && showHidden)) {
                         resultFiles.add(f);
                     }
                     continue;
                 }
 
-                if (f.isDirectory() && !directoriesFilter) {
+                if (fileFilter != null) {
+                    if (fileFilter.matcher(f.getName()).matches())
+                        if (!f.isHidden() || (f.isHidden() && showHidden)) {
+                            resultFiles.add(f);
+                        }
+                } else {
                     resultFiles.add(f);
-                    continue;
                 }
 
-                if (fileFilter != null && fileFilter.matcher(f.getName()).matches()) {
-                    resultFiles.add(f);
-                }
             }
 
             Collections.sort(resultFiles, new FileComparator());


### PR DESCRIPTION
Fixed file filters. 
Now filters work for hidden files and folders - #19;

Also, as in #11 issue if user don't specify filters he expect all files to be visible.
For example:
  new MaterialFilePicker()
                .withActivity(this)
                .withRequestCode(1)
                .withFilterDirectories(false)
                .withHiddenFiles(true)
                .start();
    
In this scenario all folders was empty. To show all files user had to set filter like .withFilter(Pattern.compile(".*\\.*")) or something like that.
Now all files will be shown by default.