### PR TITLE
Don't enforce application attributes in library manifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -2,9 +2,7 @@
     package="com.nbsp.materialfilepicker">
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
-    <application
-        android:allowBackup="true"
-        android:supportsRtl="true">
+    <application>
 
         <activity android:name=".ui.FilePickerActivity"
             android:theme="@style/MFP_BaseTheme">


### PR DESCRIPTION
Library AndroidManifest.xml file shouldn't contain allowBackup and supportsRtl fields. It can cause unnecessary confilcts with manifest merger.