### PR TITLE
Optimized 'withCustomActivity' method.

### DIFF
--- a/library/src/main/java/com/nbsp/materialfilepicker/MaterialFilePicker.java
+++ b/library/src/main/java/com/nbsp/materialfilepicker/MaterialFilePicker.java
@@ -22,7 +22,7 @@ public class MaterialFilePicker {
     private Fragment mFragment;
     private android.support.v4.app.Fragment mSupportFragment;
 
-    private Class<?> mFilePickerClass = FilePickerActivity.class;
+    private Class<? extends FilePickerActivity> mFilePickerClass = FilePickerActivity.class;
 
     private Integer mRequestCode;
     private Pattern mFileFilter;
@@ -150,9 +150,7 @@ public class MaterialFilePicker {
         return this;
     }
 
-    public MaterialFilePicker withCustomActivity(Class<?> customActivityClass) {
-        if (!FilePickerActivity.class.isAssignableFrom(customActivityClass))
-            throw new RuntimeException("Your custom class must extend FilePickerActivity class");
+    public MaterialFilePicker withCustomActivity(Class<? extends FilePickerActivity> customActivityClass) {
         mFilePickerClass = customActivityClass;
         return this;
     }


### PR DESCRIPTION
I forgot to add it on the last PR, sorry.

Now you can only pass a Class which extends from FilePickerActivity, so there's no need to check it on runtime at 'withCustomActivity' method.