### PR TITLE
Fixed #79, crash caused by null pointer if ARG_CLOSEABLE is not passed as Extra

### DIFF
--- a/library/src/main/java/com/nbsp/materialfilepicker/ui/FilePickerActivity.java
+++ b/library/src/main/java/com/nbsp/materialfilepicker/ui/FilePickerActivity.java
@@ -102,6 +102,8 @@ public class FilePickerActivity extends AppCompatActivity implements DirectoryFr
 
         if (getIntent().hasExtra(ARG_CLOSEABLE)) {
             mCloseable = getIntent().getBooleanExtra(ARG_CLOSEABLE, true);
+        } else {
+            mCloseable = Boolean.TRUE;
         }
     }
 


### PR DESCRIPTION
Added else condition initializing the Boolean value.